### PR TITLE
Fix time format

### DIFF
--- a/mrblib/logger.rb
+++ b/mrblib/logger.rb
@@ -339,7 +339,7 @@ class Logger
     private
 
     def format_datetime(t)
-      format (@datetime_format || '%d-%d-%dT%d:%d:%d.%6d '), t.year, t.mon, t.day, t.hour, t.min, t.sec, t.usec
+      format (@datetime_format || '%04d-%02d-%02dT%02d:%02d:%02d.%06d '), t.year, t.mon, t.day, t.hour, t.min, t.sec, t.usec
     rescue
       t.asctime
     end

--- a/test/logger.rb
+++ b/test/logger.rb
@@ -114,10 +114,19 @@ assert 'Logger#add', 'severity+message' do
   logdev = StringIO.new
   logger = Logger.new(logdev)
 
-  logger.add INFO, 'message'
+  begin
+    def Time.now
+      return Time.mktime(123, 1, 2, 3, 4, 5, 67890)
+    end
+    logger.add INFO, 'message'
+  ensure
+    def Time.now
+      return new
+    end
+  end
 
-  assert_equal 'I, [', logdev.to_s[0..3]
-  assert_include logdev.to_s, ']  INFO -- : message'
+  assert_equal "I, [0123-01-02T03:04:05.067890 #0]  INFO -- : message\n",
+               logdev.to_s
 end
 
 assert 'Logger#add', 'severity+proc' do


### PR DESCRIPTION
This pull-request gives more compatibility with CRuby.

## Before pull-request

```
% ./bin/mruby -e '
  logdev = StringIO.new
  logger = Logger.new(logdev)
  def Time.now
    return Time.mktime(123, 1, 2, 3, 4, 5, 67890)
  end
  logger.add Logger::INFO, "message"
  p logdev.string
'
"I, [123-1-2T3:4:5. 67890  #6625]  INFO -- : message\n"
```

## CRuby's Logger output

```
% ruby -v -rstringio -rlogger -ve '
  logdev = StringIO.new
  logger = Logger.new(logdev)
  def Time.now
    return Time.mktime(123, 1, 2, 3, 4, 5, 67890)
  end
  logger.add(Logger::INFO, "message")
  p logdev.string
'
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux]
-e:4: warning: method redefined; discarding old now
"I, [0123-01-02T03:04:05.067890 #32652]  INFO -- : message\n"
```

## After pull-requst

```
$ ./bin/mruby -e '
  logdev = StringIO.new
  logger = Logger.new(logdev)
  def Time.now
    return Time.mktime(123, 1, 2, 3, 4, 5, 67890)
  end
  logger.add Logger::INFO, "message"
  p logdev.string
'
"I, [0123-01-02T03:04:05.067890 #16947]  INFO -- : message\n"
```
